### PR TITLE
Modernize package baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+coverage/
+dist/
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2012 Itamar Weiss and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,109 @@
 # Kalman
 
-Kalman filter for Javascript.
+A small linear Kalman filter for JavaScript.
 
-## Dependencies
-The module requires a sylvester.js (https://github.com/jcoglan/sylvester) compatible matrix and vector manipulation module.
+This project is being modernized. The `0.1.x` line keeps the original
+Sylvester-compatible API while adding package metadata, CommonJS and ESM entry
+points, TypeScript declarations, deterministic tests, and CI.
+
+## Install
+
+```sh
+npm install @itamarwe/kalman
+```
+
+## Requirements
+
+The compatibility API still expects a Sylvester-compatible matrix and vector
+implementation. The objects passed to the filter must support the methods used
+by Sylvester, including `x`, `add`, `subtract`, `transpose`, `inverse`, `rows`,
+and vector/matrix element accessors.
 
 ## Usage
-Using the Kalman Filter module is very simple:
+
+### CommonJS
+
+```js
+const { KalmanModel, KalmanObservation } = require('@itamarwe/kalman');
+```
+
+### ESM
+
+```js
+import { KalmanModel, KalmanObservation } from '@itamarwe/kalman';
+```
+
+### Browser Globals
 
 ```html
-<script type="text/javascript" src="sylvester.src.js"></script>
-<script type="text/javascript" src="../kalman.js"></script>
+<script src="sylvester.src.js"></script>
+<script src="kalman.js"></script>
 
-<script type="text/javascript">
+<script>
 var x_0 = $V([-10]);
 var P_0 = $M([[1]]);
-var F_k=$M([[1]]);
-var Q_k=$M([[0]]);
-var KM = new KalmanModel(x_0,P_0,F_k,Q_k);
+var F_k = $M([[1]]);
+var Q_k = $M([[0]]);
+var model = new KalmanModel(x_0, P_0, F_k, Q_k);
 
 var z_k = $V([1]);
 var H_k = $M([[1]]);
 var R_k = $M([[4]]);
-var KO = new KalmanObservation(z_k,H_k,R_k);
+var observation = new KalmanObservation(z_k, H_k, R_k);
 
-for (var i=0;i<200;i++){
-  z_k = $V([0.5+Math.random()]);
-  KO.z_k=z_k;
-  KM.update(KO);
-  console.log(JSON.stringify(KM.x_k.elements));
-}
+model.update(observation);
+
+console.log(model.x_k.elements);
 </script>
 ```
+
+## API
+
+### `new KalmanModel(x_0, P_0, F_k, Q_k)`
+
+Creates a filter model with initial state `x_0`, initial covariance `P_0`,
+state transition model `F_k`, and process noise covariance `Q_k`.
+
+### `new KalmanObservation(z_k, H_k, R_k)`
+
+Creates an observation with measurement `z_k`, observation model `H_k`, and
+observation noise covariance `R_k`.
+
+### `model.predict()`
+
+Runs the prediction step and stores the predicted state in `model.x_k_k_` and
+predicted covariance in `model.P_k_k_`.
+
+### `model.correct(observation)`
+
+Runs the correction step against the most recent prediction and updates
+`model.x_k` and `model.P_k`.
+
+### `model.update(observation)`
+
+Runs the current predict-and-correct step and updates `model.x_k` and
+`model.P_k`. This is equivalent to calling `model.predict()` followed by
+`model.correct(observation)`.
+
+## Development
+
+```sh
+npm test
+```
+
+The test suite loads the vendored Sylvester build the same way the original
+browser test did, then verifies deterministic scalar filter behavior and module
+exports.
+
+## Modernization Roadmap
+
+- Add a modern dependency-light matrix layer or adapter API.
+- Improve numerical stability by avoiding direct inverses where possible.
+- Publish a migration guide from the compatibility API to the modern API.
+
 ## License
 
-(The MIT License)
+MIT. See [LICENSE](LICENSE).
 
-Copyright (c) 2007-2012 James Coglan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the 'Software'), to deal in
-the Software without restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
-Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The vendored `test/sylvester.src.js` file is MIT licensed by James Coglan and
+is used only for compatibility tests.

--- a/kalman.d.ts
+++ b/kalman.d.ts
@@ -1,0 +1,69 @@
+export interface SylvesterVector {
+  elements: number[];
+  e(index: number): number | null;
+  add(vector: SylvesterVector): SylvesterVector;
+  subtract(vector: SylvesterVector): SylvesterVector;
+}
+
+export interface SylvesterMatrix {
+  elements: number[][];
+  e(row: number, column: number): number | null;
+  rows(): number;
+  x(matrix: SylvesterMatrix): SylvesterMatrix;
+  x(vector: SylvesterVector): SylvesterVector;
+  add(matrix: SylvesterMatrix): SylvesterMatrix;
+  subtract(matrix: SylvesterMatrix): SylvesterMatrix;
+  transpose(): SylvesterMatrix;
+  inverse(): SylvesterMatrix;
+}
+
+export declare const Kalman: {
+  version: string;
+};
+
+export declare class KalmanModel {
+  constructor(
+    x_0: SylvesterVector,
+    P_0: SylvesterMatrix,
+    F_k: SylvesterMatrix,
+    Q_k: SylvesterMatrix
+  );
+
+  x_k: SylvesterVector;
+  P_k: SylvesterMatrix;
+  F_k: SylvesterMatrix;
+  Q_k: SylvesterMatrix;
+
+  I?: SylvesterMatrix;
+  x_k_?: SylvesterVector;
+  P_k_?: SylvesterMatrix;
+  x_k_k_?: SylvesterVector;
+  P_k_k_?: SylvesterMatrix;
+  y_k?: SylvesterVector;
+  S_k?: SylvesterMatrix;
+  K_k?: SylvesterMatrix;
+
+  predict(): void;
+  correct(observation: KalmanObservation): void;
+  update(observation: KalmanObservation): void;
+}
+
+export declare class KalmanObservation {
+  constructor(
+    z_k: SylvesterVector,
+    H_k: SylvesterMatrix,
+    R_k: SylvesterMatrix
+  );
+
+  z_k: SylvesterVector;
+  H_k: SylvesterMatrix;
+  R_k: SylvesterMatrix;
+}
+
+declare const api: {
+  Kalman: typeof Kalman;
+  KalmanModel: typeof KalmanModel;
+  KalmanObservation: typeof KalmanObservation;
+};
+
+export default api;

--- a/kalman.js
+++ b/kalman.js
@@ -20,47 +20,84 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-var Kalman = {
-  version: '0.0.1'
-};
+(function(root, factory) {
+  var api = factory(root);
 
-KalmanModel = (function(){
-
-  function KalmanModel(x_0,P_0,F_k,Q_k){
-    this.x_k  = x_0;
-    this.P_k  = P_0;
-    this.F_k  = F_k;
-    this.Q_k  = Q_k;
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
   }
-  
-  KalmanModel.prototype.update =  function(o){
-    this.I = Matrix.I(this.P_k.rows());
-    //init
-    this.x_k_ = this.x_k;
-    this.P_k_ = this.P_k;
 
-    //Predict
-    this.x_k_k_ = this.F_k.x(this.x_k_);
-    this.P_k_k_ = this.F_k.x(this.P_k_.x(this.F_k.transpose())).add(this.Q_k);
-    
-    //update
-    this.y_k = o.z_k.subtract(o.H_k.x(this.x_k_k_));//observation residual
-    this.S_k = o.H_k.x(this.P_k_k_.x(o.H_k.transpose())).add(o.R_k);//residual covariance
-    this.K_k = this.P_k_k_.x(o.H_k.transpose().x(this.S_k.inverse()));//Optimal Kalman gain
-    this.x_k = this.x_k_k_.add(this.K_k.x(this.y_k));
-    this.P_k = this.I.subtract(this.K_k.x(o.H_k)).x(this.P_k_k_);
+  if (root) {
+    root.Kalman = api.Kalman;
+    root.KalmanModel = api.KalmanModel;
+    root.KalmanObservation = api.KalmanObservation;
   }
-  
-  return KalmanModel;
-})();
+}(typeof globalThis !== 'undefined' ? globalThis : this, function(root) {
+  'use strict';
 
-KalmanObservation = (function(){
+  var Kalman = {
+    version: '0.1.0'
+  };
 
-  function KalmanObservation(z_k,H_k,R_k){
-    this.z_k = z_k;//observation
-    this.H_k = H_k;//observation model
-    this.R_k = R_k;//observation noise covariance
+  function getMatrix() {
+    if (root && root.Matrix) {
+      return root.Matrix;
+    }
+
+    throw new Error('Kalman requires a Sylvester-compatible Matrix implementation.');
   }
-  
-  return KalmanObservation;
-})();
+
+  var KalmanModel = (function() {
+
+    function KalmanModel(x_0, P_0, F_k, Q_k) {
+      this.x_k = x_0;
+      this.P_k = P_0;
+      this.F_k = F_k;
+      this.Q_k = Q_k;
+    }
+
+    KalmanModel.prototype.predict = function() {
+      //init
+      this.x_k_ = this.x_k;
+      this.P_k_ = this.P_k;
+
+      //Predict
+      this.x_k_k_ = this.F_k.x(this.x_k_);
+      this.P_k_k_ = this.F_k.x(this.P_k_.x(this.F_k.transpose())).add(this.Q_k);
+    };
+
+    KalmanModel.prototype.correct = function(o) {
+      this.I = getMatrix().I(this.P_k.rows());
+      //update
+      this.y_k = o.z_k.subtract(o.H_k.x(this.x_k_k_));//observation residual
+      this.S_k = o.H_k.x(this.P_k_k_.x(o.H_k.transpose())).add(o.R_k);//residual covariance
+      this.K_k = this.P_k_k_.x(o.H_k.transpose().x(this.S_k.inverse()));//Optimal Kalman gain
+      this.x_k = this.x_k_k_.add(this.K_k.x(this.y_k));
+      this.P_k = this.I.subtract(this.K_k.x(o.H_k)).x(this.P_k_k_);
+    };
+
+    KalmanModel.prototype.update = function(o) {
+      this.predict();
+      this.correct(o);
+    };
+
+    return KalmanModel;
+  })();
+
+  var KalmanObservation = (function() {
+
+    function KalmanObservation(z_k, H_k, R_k) {
+      this.z_k = z_k;//observation
+      this.H_k = H_k;//observation model
+      this.R_k = R_k;//observation noise covariance
+    }
+
+    return KalmanObservation;
+  })();
+
+  return {
+    Kalman: Kalman,
+    KalmanModel: KalmanModel,
+    KalmanObservation: KalmanObservation
+  };
+}));

--- a/kalman.mjs
+++ b/kalman.mjs
@@ -1,0 +1,7 @@
+import kalman from './kalman.js';
+
+export const Kalman = kalman.Kalman;
+export const KalmanModel = kalman.KalmanModel;
+export const KalmanObservation = kalman.KalmanObservation;
+
+export default kalman;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@itamarwe/kalman",
+  "version": "0.1.0",
+  "description": "A small linear Kalman filter for JavaScript.",
+  "license": "MIT",
+  "author": "Itamar Weiss",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/itamarwe/kalman.git"
+  },
+  "bugs": {
+    "url": "https://github.com/itamarwe/kalman/issues"
+  },
+  "homepage": "https://github.com/itamarwe/kalman#readme",
+  "keywords": [
+    "kalman",
+    "kalman-filter",
+    "filter",
+    "estimation",
+    "sensor-fusion"
+  ],
+  "main": "./kalman.js",
+  "module": "./kalman.mjs",
+  "types": "./kalman.d.ts",
+  "exports": {
+    ".": {
+      "types": "./kalman.d.ts",
+      "import": "./kalman.mjs",
+      "require": "./kalman.js",
+      "default": "./kalman.js"
+    }
+  },
+  "files": [
+    "kalman.js",
+    "kalman.mjs",
+    "kalman.d.ts",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/test/kalman.test.js
+++ b/test/kalman.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+const vm = require('node:vm');
+const { pathToFileURL } = require('node:url');
+
+const root = path.join(__dirname, '..');
+const sylvesterPath = path.join(__dirname, 'sylvester.src.js');
+const kalmanPath = path.join(root, 'kalman.js');
+
+vm.runInThisContext(fs.readFileSync(sylvesterPath, 'utf8'), {
+  filename: sylvesterPath
+});
+
+const {
+  Kalman,
+  KalmanModel,
+  KalmanObservation
+} = require('../kalman.js');
+
+function assertClose(actual, expected, tolerance = 1e-12) {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ${tolerance} of ${expected}`
+  );
+}
+
+function createScalarModel() {
+  return new KalmanModel(
+    $V([-10]),
+    $M([[1]]),
+    $M([[1]]),
+    $M([[0]])
+  );
+}
+
+function createScalarObservation(measurement) {
+  return new KalmanObservation(
+    $V([measurement]),
+    $M([[1]]),
+    $M([[4]])
+  );
+}
+
+test('exports the compatibility API for CommonJS users', () => {
+  assert.equal(Kalman.version, '0.1.0');
+  assert.equal(typeof KalmanModel, 'function');
+  assert.equal(typeof KalmanObservation, 'function');
+});
+
+test('exports the compatibility API for ESM users', async () => {
+  const module = await import(pathToFileURL(path.join(root, 'kalman.mjs')).href);
+
+  assert.equal(module.Kalman.version, '0.1.0');
+  assert.equal(module.default.KalmanModel, module.KalmanModel);
+  assert.equal(module.default.KalmanObservation, module.KalmanObservation);
+});
+
+test('updates scalar state and covariance deterministically', () => {
+  const model = createScalarModel();
+  const observation = createScalarObservation(1);
+
+  model.update(observation);
+
+  assertClose(model.x_k.e(1), -7.8);
+  assertClose(model.P_k.e(1, 1), 0.8);
+  assertClose(model.y_k.e(1), 11);
+  assertClose(model.S_k.e(1, 1), 5);
+  assertClose(model.K_k.e(1, 1), 0.2);
+});
+
+test('supports split predict and correct steps', () => {
+  const model = createScalarModel();
+  const observation = createScalarObservation(1);
+
+  model.predict();
+
+  assertClose(model.x_k_k_.e(1), -10);
+  assertClose(model.P_k_k_.e(1, 1), 1);
+
+  model.correct(observation);
+
+  assertClose(model.x_k.e(1), -7.8);
+  assertClose(model.P_k.e(1, 1), 0.8);
+});
+
+test('preserves current behavior across repeated scalar updates', () => {
+  const model = createScalarModel();
+  const observation = createScalarObservation(1);
+
+  for (const measurement of [1, 0.5, 1.5]) {
+    observation.z_k = $V([measurement]);
+    model.update(observation);
+  }
+
+  assertClose(model.x_k.e(1), -37 / 7);
+  assertClose(model.P_k.e(1, 1), 4 / 7);
+});
+
+test('attaches globals when loaded as browser scripts', () => {
+  const sandbox = {
+    console: {
+      log() {}
+    }
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+
+  vm.runInContext(fs.readFileSync(sylvesterPath, 'utf8'), sandbox, {
+    filename: sylvesterPath
+  });
+  vm.runInContext(fs.readFileSync(kalmanPath, 'utf8'), sandbox, {
+    filename: kalmanPath
+  });
+
+  assert.equal(sandbox.Kalman.version, '0.1.0');
+  assert.equal(typeof sandbox.KalmanModel, 'function');
+  assert.equal(typeof sandbox.KalmanObservation, 'function');
+
+  const model = new sandbox.KalmanModel(
+    sandbox.$V([-10]),
+    sandbox.$M([[1]]),
+    sandbox.$M([[1]]),
+    sandbox.$M([[0]])
+  );
+  const observation = new sandbox.KalmanObservation(
+    sandbox.$V([1]),
+    sandbox.$M([[1]]),
+    sandbox.$M([[4]])
+  );
+
+  model.update(observation);
+
+  assertClose(model.x_k.e(1), -7.8);
+  assertClose(model.P_k.e(1, 1), 0.8);
+});

--- a/test/test.html
+++ b/test/test.html
@@ -1,35 +1,32 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>kalman.js Test Suite</title>
+<title>kalman.js browser compatibility smoke test</title>
 <script type="text/javascript" src="sylvester.src.js"></script>
 <script type="text/javascript" src="../kalman.js"></script>
 
 <script type="text/javascript">
 var x_0 = $V([-10]);
 var P_0 = $M([[1]]);
-var F_k=$M([[1]]);
-var Q_k=$M([[0]]);
-var KM = new KalmanModel(x_0,P_0,F_k,Q_k);
+var F_k = $M([[1]]);
+var Q_k = $M([[0]]);
+var KM = new KalmanModel(x_0, P_0, F_k, Q_k);
 
 var z_k = $V([1]);
 var H_k = $M([[1]]);
 var R_k = $M([[4]]);
-var KO = new KalmanObservation(z_k,H_k,R_k);
+var KO = new KalmanObservation(z_k, H_k, R_k);
 
-for (var i=0;i<200;i++){
-  z_k = $V([0.5+Math.random()]);
-  KO.z_k=z_k;
-  KM.update(KO);
-  console.log(KM.x_k.elements);
-}
+KM.update(KO);
+console.log('state', KM.x_k.elements);
+console.log('covariance', KM.P_k.elements);
 
 
 </script>
 </head>
 
 <body>
-kalman.js Test Suite
+kalman.js browser compatibility smoke test
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Add npm package metadata, MIT license, ESM bridge, TypeScript declarations, and CI
- Wrap the legacy globals with CommonJS/browser-compatible exports
- Add split predict/correct methods while preserving update() compatibility
- Replace random browser logging with deterministic tests and a browser smoke page

## Tests
- npm test